### PR TITLE
Caesar algorithm is bogus.

### DIFF
--- a/tests/caesarlib.rs
+++ b/tests/caesarlib.rs
@@ -19,6 +19,14 @@ mod tests {
         assert_ne!(encipher(13, "FooBar"), encipher(14, "FooBar"));
     }
     #[test]
+    fn ciphered_text_with_offset_0_is_message() {
+        assert_eq!(encipher(0, "FooBar"), "FooBar");
+    }
+    #[test]
+    fn ciphered_text_with_offset_1_is_message() {
+        assert_eq!(encipher(1, "FooBar"), "GppCbs");
+    }
+    #[test]
     fn ciphered_text_can_contains_unknown_chars() {
         let enciphered = encipher(13, "Foo:bar.");
         assert_eq!("Foo:bar.", decipher(13, &enciphered));

--- a/tests/caesarlib.rs
+++ b/tests/caesarlib.rs
@@ -23,8 +23,16 @@ mod tests {
         assert_eq!(encipher(0, "FooBar"), "FooBar");
     }
     #[test]
-    fn ciphered_text_with_offset_1_is_message() {
+    fn ciphered_text_with_offset_1_is_ciphered() {
         assert_eq!(encipher(1, "FooBar"), "GppCbs");
+    }
+    #[test]
+    fn deciphered_text_with_offset_0_is_message() {
+        assert_eq!(decipher(0, "FooBar"), "FooBar");
+    }
+    #[test]
+    fn deciphered_text_with_offset_1_is_deciphered() {
+        assert_eq!(decipher(0, "FooBar"), "EnnAzq");
     }
     #[test]
     fn ciphered_text_can_contains_unknown_chars() {


### PR DESCRIPTION
When playing around with ``--random`` I discovered that the expected ``encipher`` results wasn't accurate:

```sh
$ caesarlib encipher -s 0 FooBar
FooBar
$ caesarlib encipher -s 1 FooBar
FooBar
```

Apparently there is an offset of 1 in the ``shift_seq`` function.