### PR TITLE
Prepare for 0.1.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caesarlib"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["caesarlib org <lamuller@protonmail.com>"]
 description = "A Caesar-Cipher library for Rust."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-caesarlib = "0.1.2"
+caesarlib = "0.1.3"
 ```
 
 and this to your crate root:

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
         .get_matches();
 
     let input_text = matches.value_of("TEXT").unwrap();
-    
+
     let mut result;
 
     match matches.is_present("RANDOM") {


### PR DESCRIPTION
Shall 0.1.3 be released as it improves the performance of the algorithm (e.g. enciphering at offset 1 and performance at offsets higher than the base sequence length) ?